### PR TITLE
Documenting install discrepancies on linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,9 +43,34 @@ microbenchmark of 24 CSV parsers.
 
 ## Python Usage
 
-1. `pip install -e . # or similar`
+You can install the library through pip:
+
+```
+pip install csvmonkey
+```
+
+If this fails on ubuntu, first install `clang`:
+
+```
+sudo apt-get install clang
+```
+
+Then run:
+
+```
+CC=clang pip install csvmonkey
+```
+
+You can also install the library locally by cloning this repo and running:
+
+```
+pip install -e .
+```
+
+Then you can use it likewise:
+
 1. `import csvmonkey`
-1. `csvmonkey.from_path()` for a memory-mapped file, `csvmonkey.from_file()`
+2. `csvmonkey.from_path()` for a memory-mapped file, `csvmonkey.from_file()`
    for any file-like object with a `read()` method, or `csvmonkey.from_iter()`
    for any iterable object that yields lines or file chunks, e.g.
    `from_iter(open("ram.csv"))`.


### PR DESCRIPTION
Hello @dw, just a PR to document how to install the lib on ubuntu etc. because it is failing right now because, on linux, install will default to gcc compilation most of the time and your files cannot be compiled using gcc because of the following error (note that I am using py3):

```
cpython/csvmonkey.cpp:933:1: sorry, unimplemented: non-trivial designated initializers not supported
```

related to this piece of code:

```c++
PyTypeObject CellType = {
    PyVarObject_HEAD_INIT(NULL, 0)
    .tp_name = "_Cell",
    .tp_basicsize = sizeof(CellObject),
    .tp_dealloc = cell_dealloc,
#if PY_MAJOR_VERSION < 3
    .tp_compare = cell_compare,
#endif
    .tp_flags=Py_TPFLAGS_DEFAULT,
    .tp_doc="csvmonkey._Cell",
    .tp_richcompare=cell_richcmp,
    .tp_methods=cell_methods,
};
```

I'd fix it myself if I could but I don't know much about C++.

Have a good day and thanks for your library.